### PR TITLE
Makefile.PL: Add Types::Serialiser as dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ WriteMakefile(
         'HTTP::Tiny::UA::Response' => 0.004,
         'JSON'                     => 2.9,
         'MIME::Base64'             => 3.11,
+        'Types::Serialiser'        => 1.0,
         'X::Tiny'                  => 0.12,
     },
     META_MERGE => {


### PR DESCRIPTION
`lib/Net/ACME2.pm` requires `Types::Serialiser`, which is not in core or listed as a dependency of this distribution (either directly or indirectly through `Net::ACME2`'s other dependencies).

`Types::Serialiser` is pure Perl, so this doesn't break `Net::ACME2`'s "pure Perl or core" invariant.