### PR TITLE
Remove dependency on Types::Serialiser

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,6 @@ WriteMakefile(
         'HTTP::Tiny::UA::Response' => 0.004,
         'JSON'                     => 2.9,
         'MIME::Base64'             => 3.11,
-        'Types::Serialiser'        => 1.0,
         'X::Tiny'                  => 0.12,
     },
     META_MERGE => {

--- a/lib/Net/ACME2.pm
+++ b/lib/Net/ACME2.pm
@@ -118,7 +118,6 @@ Specific error classes aren’t yet defined.
 
 use Crypt::Format ();
 use MIME::Base64 ();
-use Types::Serialiser ();
 
 use Net::ACME2::Constants ();
 use Net::ACME2::HTTP ();
@@ -242,7 +241,7 @@ or 0 if the account already existed.
 sub create_new_account {
     my ($self, %opts) = @_;
 
-    $opts{$_} &&= Types::Serialiser::true() for newAccount_booleans();
+    $opts{$_} &&= JSON::true() for newAccount_booleans();
 
     my $resp = $self->_post(
         'newAccount',


### PR DESCRIPTION
`Types::Serialiser` has a dependency on `common::sense`, which currently doesn't contain architecture-specific code but (as of version 3.7) reserves the right to in a future release; it's already installed into an architecture-specific subdirectory in `PERL5LIB`. If such code were to be added to `common::sense`, this would break `Net::ACME2`'s "pure Perl or core dependencies" invariant.

`Types::Serialiser` is only used once, and this occurrence can be replaced with a call to an equivalent function that already exists in `JSON.pm`. This removes `Net::ACME2`'s dependency on `Types::Serialiser`, and therefore `common::sense`.

(Apologies for submitting this so soon after PR #2: it wasn't until I started installing `Net::ACME2` and its dependencies into a clean `local::lib` that I realised what was actually going on...)