### PR TITLE
lib/Net/ACME2/LetsEncrypt.pm: Changed the default back to PRODUCTION

### DIFF
--- a/lib/Net/ACME2/LetsEncrypt.pm
+++ b/lib/Net/ACME2/LetsEncrypt.pm
@@ -28,8 +28,8 @@ use constant {
     #JWS_FORMAT => 'compact',   #v1 supported this?
 };
 
-*HOST = *_STAGING_SERVER;
+#*HOST = *_STAGING_SERVER;
 
-#*HOST = *_PRODUCTION_SERVER;
+*HOST = *_PRODUCTION_SERVER;
 
 1;


### PR DESCRIPTION
Please consider, changing the default host back to production.
I have more then 10k machines using Net::ACME2 and have to constantly check if LetsEncrypt.pm is actually with the PRODUCTION host.

- If it is left as staging, the first time you install the module on production server, you have to immediately to edit this file, so you can set it to PRODUCTION.
Also if you update the module on a production machine, it reverts back to STAGING, which is definately bad for production environments.

Signed-off-by: Marian Marinov <mm@yuhu.biz>