### PR TITLE
Fix a warning from Net::ACME2::Error::to_string

### DIFF
--- a/lib/Net/ACME2/Error.pm
+++ b/lib/Net/ACME2/Error.pm
@@ -120,7 +120,7 @@ sub subproblems {
 sub to_string {
     my ($self) = @_;
 
-    my $str = $self->status() . ' ' . $self->type();
+    my $str = join( q< >, grep { defined } $self->status(), $self->type() );
 
     for my $attribute ( qw( title description detail instance ) ) {
         my $value = $self->$attribute();


### PR DESCRIPTION
Fixes GH #8

Smoke with the GitHub actions there
https://github.com/atoomic/p5-Net-ACME2/actions/runs/47122296